### PR TITLE
Moved logManager and runtimeClassManager to start at the Start() func…

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -346,7 +346,9 @@ func (e *edged) Start() {
 		klog.Errorf("Failed to start container manager, err: %v", err)
 		return
 	}
-
+	e.logManager.Start()
+	stopChan := make(chan struct{})
+	e.runtimeClassManager.Start(stopChan)
 	klog.Infof("starting syncPod")
 	e.syncPod()
 }
@@ -575,7 +577,7 @@ func newEdged(enable bool) (*edged, error) {
 		machineInfo.MemoryCapacity = uint64(edgedconfig.Config.EdgedMemoryCapacity)
 		ed.machineInfo = &machineInfo
 	}
-	// creat a log manager
+	// create a log manager
 	logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "1", 2)
 	if err != nil {
 		return nil, fmt.Errorf("New container log manager failed, err: %s", err.Error())
@@ -729,9 +731,7 @@ func (e *edged) initializeModules() error {
 		klog.Errorf("Failed to start container manager, err: %v", err)
 		return err
 	}
-	e.logManager.Start()
-	stopChan := make(chan struct{})
-	e.runtimeClassManager.Start(stopChan)
+
 	return nil
 }
 


### PR DESCRIPTION
…tion. Fixed typo

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind api-change
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
Updates k8s to x.19.3
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
New binaries' size:
```
  File: cloudcore
  Size: 36458496  	Blocks: 71208      IO Block: 4096   regular file

  File: edgecore
  Size: 78478800  	Blocks: 153288     IO Block: 4096   regular file

  File: keadm
  Size: 36704256  	Blocks: 71688      IO Block: 4096   regular file
```

binaries size for versino 1.14:
```
  File: cloudcore
  Size: 46442976  	Blocks: 90712      IO Block: 4096   regular file

  File: edgecore
  Size: 101401880 	Blocks: 198064     IO Block: 4096   regular file

  File: keadm
  Size: 39941925  	Blocks: 78016      IO Block: 4096   regular file
```

Memory usage for new cloud/edge core:
cloudcore:
<img width="637" alt="Screen Shot 2020-10-30 at 11 18 23 AM" src="https://user-images.githubusercontent.com/32083634/97743803-74699500-1aa3-11eb-8375-57287f5dd8e5.png">
edgecore:
<img width="596" alt="Screen Shot 2020-10-30 at 11 18 49 AM" src="https://user-images.githubusercontent.com/32083634/97743857-8814fb80-1aa3-11eb-9203-eb95c4da88ad.png">

Memory usage for version 1.14 cloud/edge core:
cloudcore:
![Screen Shot 2020-10-30 at 11 39 24 AM](https://user-images.githubusercontent.com/32083634/97744578-b5ae7480-1aa4-11eb-865c-ce245951dd4c.png)
edgecore:
![Screen Shot 2020-10-30 at 11 39 46 AM](https://user-images.githubusercontent.com/32083634/97744585-b941fb80-1aa4-11eb-9930-154be8005bc3.png)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
